### PR TITLE
fix my previous blocking fix

### DIFF
--- a/pkg/client/remote.go
+++ b/pkg/client/remote.go
@@ -25,7 +25,7 @@ func New(ctx context.Context, endpoint string) (Client, error) {
 		endpoint = DefaultEndpoint
 	}
 
-	conn, err := endpointconn.Get(ctx, endpoint)
+	conn, err := endpointconn.Get(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -42,7 +42,7 @@ func newDaemon(ctx context.Context, endpoint string) (*Daemon, error) {
 	if endpoint == "" {
 		endpoint = DefaultContainerdEndpoint
 	}
-	runtimeConn, err := endpointconn.Get(ctx, endpoint)
+	runtimeConn, err := endpointconn.Get(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/endpointconn/endpoint.go
+++ b/pkg/endpointconn/endpoint.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func Get(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+func Get(ctx context.Context, endpoint string, dialOpts ... grpc.DialOption) (*grpc.ClientConn, error) {
 	if !strings.HasPrefix(endpoint, "unix://") {
 		endpoint = "unix://" + endpoint
 	}
@@ -18,7 +18,7 @@ func Get(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithContextDialer(dialer), grpc.FailOnNonTempDialError(true))
+	conn, err := grpc.DialContext(ctx, target, append(dialOpts, grpc.WithContextDialer(dialer))...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the daemon is failing to start because it is attempting to connect to the containerd socker before it is available.

this fix-for-the-fix refactors endpointconn.Get to accept varying array of grpc.DialOption which allows the daemon to block/retry while dialing containerd socket but client connections will not block if they are lacking perms on the k3c socket.