### PR TITLE
fix default cri config

### DIFF
--- a/cmd/daemon/daemon_linux.go
+++ b/cmd/daemon/daemon_linux.go
@@ -171,7 +171,7 @@ func writeConfig(cfg *containerd.Config, path string, cniConf, cniConfList map[s
 			case "k3c":
 				// TODO(dweomer): nothing to do here ... yet
 			case "cri":
-				xfg, ok := p.Config.(*cri.Config)
+				xfg, ok := p.Config.(*cri.PluginConfig)
 				if !ok {
 					return fmt.Errorf("unexpected config type for plugin %q: %T", p.ID, p.Config)
 				}

--- a/pkg/daemon/config/cri.go
+++ b/pkg/daemon/config/cri.go
@@ -11,19 +11,18 @@ var (
 	DefaultCriSandboxImage = "docker.io/rancher/pause:3.1"
 )
 
-func DefaultCriConfig(address, root string) *cri.Config {
-	config := &cri.Config{
-		PluginConfig:       cri.DefaultConfig(),
-		ContainerdEndpoint: address,
-		ContainerdRootDir:  root,
-	}
+func DefaultCriConfig(address, root string) *cri.PluginConfig {
+	// PluginConfig
+	config := cri.DefaultConfig()
+	config.SandboxImage = DefaultCriSandboxImage
+	// .ContainerdConfig
 	config.DefaultRuntimeName = "runc"
 	config.Runtimes = map[string]cri.Runtime{
 		config.DefaultRuntimeName: {Type: plugin.RuntimeRuncV2},
 	}
-	config.CniConfig.NetworkPluginBinDir = filepath.Join(root, "bin")
-	config.CniConfig.NetworkPluginConfDir = filepath.Join(root, "etc", "cni", "net.d")
-	config.CniConfig.NetworkPluginMaxConfNum = 1
-	config.SandboxImage = DefaultCriSandboxImage
-	return config
+	// .CniConfig
+	config.NetworkPluginBinDir = filepath.Join(root, "bin")
+	config.NetworkPluginConfDir = filepath.Join(root, "etc", "cni", "net.d")
+	config.NetworkPluginMaxConfNum = 1
+	return &config
 }


### PR DESCRIPTION
Use the CRI PluginConfig struct for default config instead of the
Config struct which is only used at runtime by the CRI service.