### PR TITLE
make: use DRONE_TAG for VERSION if present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ VOLUME /var/log
 # Dapper/Drone/CI environment
 FROM build AS dapper
 ARG GOBIN=/opt/k3c/bin
+ARG GOFLAGS=" -mod=vendor"
 ARG GOPATH=/go
 ENV GOBIN=${GOBIN} \
+    GOFLAGS=${GOFLAGS} \
     GOPATH=${GOPATH}
+
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
@@ -74,6 +77,7 @@ ARG RUNC_PACKAGE=github.com/opencontainers/runc
 ARG RUNC_BUILDTAGS="apparmor seccomp selinux"
 RUN git clone -b "${RUNC_VERSION}" "https://${RUNC_PACKAGE}.git" ${GOPATH}/src/github.com/opencontainers/runc
 WORKDIR ${GOPATH}/src/github.com/opencontainers/runc
+ENV GO111MODULE=off
 RUN set -x \
  && make BUILDTAGS="${RUNC_BUILDTAGS}" static
 RUN set -x \

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,13 @@ ifndef GOBIN
 	GOBIN := bin
 endif
 
-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.dirty' --always --tags)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
-RELEASE=${PROG}-$(VERSION).${GOOS}-${GOARCH}
+ifdef DRONE_TAG
+	VERSION = ${DRONE_TAG}
+else
+	VERSION = $(shell git describe --match 'v[0-9]*' --dirty='.dirty' --always --tags)
+endif
+REVISION = $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
+RELEASE = ${PROG}-${GOOS}-${GOARCH}
 ifndef TAG
 	TAG := $(shell echo "$(VERSION)" | tr '+' '-')-${GOARCH}
 endif
@@ -85,7 +89,7 @@ ci-shell: clean .dapper                  ## Launch a shell in the CI environment
 dapper-ci: .ci                           ## Used by Drone CI, does the same as "ci" but in a Drone way
 
 build:                                   ## Build using host go tools
-	go build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o ${GOBIN}/${PROG} -ldflags "${GO_LDFLAGS}" ${GO_TAGS}
+	go build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILDFLAGS} -o ${GOBIN}/${PROG} -ldflags "${GO_LDFLAGS}" ${GO_TAGS}
 
 build-debug:                             ## Debug build using host go tools
 	$(MAKE) GODEBUG=y build


### PR DESCRIPTION
The way drone checks out, tags are not available for `git describe`.