### PR TITLE
daemon: attempt automatic bootstrap detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,9 @@ GO_LDFLAGS ?= $(EXTRA_LDFLAGS)
 GO_LDFLAGS += -X ${PKG}/pkg/version.Version=$(VERSION)
 GO_LDFLAGS += -X ${PKG}/pkg/version.GitCommit=$(REVISION)
 GO_LDFLAGS += -X ${PKG}/pkg/daemon/config.DefaultBootstrapImage=docker.io/${IMAGE}:${TAG}
-GO_LDFLAGS += -X github.com/containerd/containerd/version.Version=$(shell grep 'github.com/containerd/containerd' go.mod | head -n1 | awk '{print $$4}')
 GO_LDFLAGS += -X github.com/containerd/containerd/version.Package=$(shell grep 'github.com/containerd/containerd' go.mod | head -n1 | awk '{print $$3}')
+GO_LDFLAGS += -X github.com/containerd/containerd/version.Revision=$(shell grep 'github.com/containerd/containerd' go.mod | head -n1 | awk '{print $$4}')
+GO_LDFLAGS += -X github.com/containerd/containerd/version.Version=$(shell grep 'github.com/containerd/containerd' go.mod | head -n1 | awk '{print $$6}')
 GO_LDFLAGS += -extldflags '${GO_EXTLDFLAGS}'
 
 default: in-docker-build                 ## Build using docker environment (default target)
@@ -98,7 +99,7 @@ package:                                 ## Build final docker image for push
 	docker build --build-arg ARCH=${GOARCH} --tag ${IMAGE}:${TAG} .
 
 bin/golangci-lint:
-	curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s ${GOLANGCI_VERSION}
+	curl -fsL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s ${GOLANGCI_VERSION}
 
 validate:                                ## Run go fmt/vet
 	go fmt ./...

--- a/cmd/daemon/daemon_linux.go
+++ b/cmd/daemon/daemon_linux.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/rancher/k3c/pkg/daemon/services/buildkit"
@@ -80,12 +81,6 @@ the backend to support the Docker work-alike frontend of k3c.`
 			EnvVar:      "K3C_BRIDGE_CIDR",
 			Destination: &daemon.Config.BridgeCIDR,
 		},
-		cliv1.BoolFlag{
-			Name:        "bootstrap-skip",
-			EnvVar:      "K3C_BOOTSTRAP_SKIP",
-			Usage:       "skip bootstrap install (default: false)",
-			Destination: &daemon.Config.BootstrapSkip,
-		},
 		cliv1.StringFlag{
 			Name:        "bootstrap-image",
 			Value:       config.DefaultBootstrapImage,
@@ -100,6 +95,56 @@ the backend to support the Docker work-alike frontend of k3c.`
 			Destination: &daemon.Config.BootstrapNamespace,
 			Hidden:      true,
 		},
+	}...)
+	defaultBootstrapSkip := true
+	requiredExecutables := map[string]string{
+		"bridge":                  "", // cni
+		"containerd-shim":         "", // containerd
+		"containerd-shim-runc-v1": "", // buildkit
+		"containerd-shim-runc-v2": "", // cri
+		"host-local":              "", // cni
+		"iptables":                "", // cni, buildkit
+		"loopback":                "", // cni
+		"portmap":                 "", // cni
+		"runc":                    "", // cri, buildkit
+		"socat":                   "", // cri
+	}
+	for bin := range requiredExecutables {
+		msg := "k3c bootstrap check"
+		if path, err := exec.LookPath(bin); err != nil {
+			defaultBootstrapSkip = false
+			logrus.WithError(err).Warn(msg)
+		} else {
+			requiredExecutables[bin] = path
+			logrus.WithField("found", path).Debug(msg)
+		}
+	}
+	if defaultBootstrapSkip {
+		app.Flags = append(app.Flags, cliv1.BoolTFlag{
+			Name:        "bootstrap-skip",
+			EnvVar:      "K3C_BOOTSTRAP_SKIP",
+			Usage:       "skip bootstrap install (default: true)",
+			Destination: &daemon.Config.BootstrapSkip,
+		})
+	} else {
+		app.Flags = append(app.Flags, cliv1.BoolFlag{
+			Name:        "bootstrap-skip",
+			EnvVar:      "K3C_BOOTSTRAP_SKIP",
+			Usage:       "skip bootstrap install (default: false)",
+			Destination: &daemon.Config.BootstrapSkip,
+		})
+	}
+	app.Flags = append(app.Flags, []cliv1.Flag{
+		cliv1.StringFlag{
+			Name:        "cni-bin",
+			EnvVar:      "K3C_CNI_BIN",
+			Destination: &daemon.Config.Namespace.NetworkPluginBinDir,
+		},
+		cliv1.StringFlag{
+			Name:        "cni-netconf",
+			EnvVar:      "K3C_CNI_NETCONF",
+			Destination: &daemon.Config.Namespace.NetworkPluginConfDir,
+		},
 		cliv1.StringFlag{
 			Name:        "sandbox-image",
 			Value:       config.DefaultSandboxImage,
@@ -108,7 +153,6 @@ the backend to support the Docker work-alike frontend of k3c.`
 			Destination: &daemon.Config.Namespace.SandboxImage,
 		},
 	}...)
-
 	app.Before = func(before cliv1.BeforeFunc) cliv1.BeforeFunc {
 		return func(clx *cliv1.Context) error {
 			// setup env
@@ -120,6 +164,8 @@ the backend to support the Docker work-alike frontend of k3c.`
 				)
 				switch t := f.(type) {
 				case cliv1.BoolFlag:
+					e = t.EnvVar
+				case cliv1.BoolTFlag:
 					e = t.EnvVar
 				case cliv1.StringFlag:
 					e = t.EnvVar
@@ -135,17 +181,32 @@ the backend to support the Docker work-alike frontend of k3c.`
 				root = clx.GlobalString("root")
 				path = filepath.Join(clx.GlobalString("root"), fmt.Sprintf("%s.cri", plugin.GRPCPlugin), "namespaces", k3c.DefaultNamespace, "config.toml")
 			)
-			daemon.Config.Namespace.NetworkPluginBinDir = filepath.Join(root, "bin")
-			daemon.Config.Namespace.NetworkPluginConfDir = filepath.Join(root, "etc", "cni", "net.d")
+			if daemon.Config.Namespace.NetworkPluginBinDir == "" {
+				daemon.Config.Namespace.NetworkPluginBinDir = filepath.Join(root, "bin")
+			}
+			if daemon.Config.Namespace.NetworkPluginConfDir == "" {
+				daemon.Config.Namespace.NetworkPluginConfDir = filepath.Join(root, "etc", "cni", "net.d")
+			}
 			buildkit.Config.Workers.Containerd.NetworkConfig.Mode = "cni"
-			buildkit.Config.Workers.Containerd.NetworkConfig.CNIBinaryPath = filepath.Join(root, "bin")
-			buildkit.Config.Workers.Containerd.NetworkConfig.CNIConfigPath = filepath.Join(root, "etc", "cni", "net.d", "90-k3c.json")
+			buildkit.Config.Workers.Containerd.NetworkConfig.CNIBinaryPath = daemon.Config.Namespace.NetworkPluginBinDir
+			buildkit.Config.Workers.Containerd.NetworkConfig.CNIConfigPath = filepath.Join(daemon.Config.Namespace.NetworkPluginConfDir, "90-k3c.json")
 
 			if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 				return err
 			}
 			if err := config.WriteFileTOML(path, &daemon.Config.Namespace, 0600); err != nil {
 				return err
+			}
+			if err := os.MkdirAll(daemon.Config.Namespace.NetworkPluginBinDir, 0700); err != nil {
+				return err
+			}
+			if defaultBootstrapSkip {
+				// the symlinking is to make buildkit happy
+				for bin, path := range requiredExecutables {
+					if err := os.Symlink(path, filepath.Join(daemon.Config.Namespace.NetworkPluginBinDir, bin)); err != nil {
+						logrus.WithError(err).Warn("k3s bootstrap skip")
+					}
+				}
 			}
 			if err := os.MkdirAll(daemon.Config.Namespace.NetworkPluginConfDir, 0700); err != nil {
 				return err


### PR DESCRIPTION
This change makes the `k3c daemon bootstrap-skip` option true-by-default
if a handful of executables can be found:
- bridge			# cni
- containerd-shim		# containerd (legacy)
- containerd-shim-runc-v1	# buildkit
- containerd-shim-runc-v2	# cri
- host-local			# cni
- iptables			# cni, buildkit
- loopback			# cni
- portmap			# cni
- runc				# cri, buildkit
- socat				# cri

If any of these are not found then the `k3c daemon --bootstrap-skip`
will revert to false-by-default meaning that, unless overridden, the
`k3c daemon` will attempt to pull down the same-version `rancher/k3c`
image and effectively `ctr install --path=${k3c.root} --libs`.

If all of these executables are found on the `$PATH` then the
`k3c daemon` will mkdir the `${k3c.root}/bin` directory and attempt
to symlink to each discovered path. If this symlinking fails then the
`k3c daemon` will fail to start.

This enables two distinct use-cases that are, operationally, very
similar:
- running the rancher/k3c container which is bundled with all needed
binaries and preventing needless image pull.
- running k3c on a host system that has containerd, cni, socat, and
iptables already installed and on the path (assumes they are working
correctly. looking at you iptables).

Related arguments added to `k3c daemon` are:
- `--cni-bin`
- `--cni-conf`
    
If left empty these DO NOT default to the typical CNI defaults of
`/opt/cni/bin` and `/etc/cni/net.d`, respectively, but instead will be
defaulted to `${k3c.root}/bin` and `${k3c.root}/etc/cni/net.d`.
