### PR TITLE
daemon: leverage exposed config of opt service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rancher/k3c
 go 1.13
 
 replace (
-	github.com/containerd/containerd => github.com/dweomer/containerd v1.3.5-0.20200416225531-efdd59c500bf // v1.3.4+k3c.1
+	github.com/containerd/containerd => github.com/dweomer/containerd v1.3.5-0.20200508232507-1139e11acb7b // v1.3.4+k3c.2
 	github.com/containerd/cri => github.com/dweomer/cri v1.11.1-0.20200508215717-5a3b30567ad1 // v1.3.0+k3c.9+unlisted
 	//github.com/containerd/cri => /go/src/github.com/containerd/cri
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20200223014041-6b972e50feee

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/dweomer/buildkit v0.6.2-0.20200111044149-7562b84375e4 h1:elGAKv3EqtjD
 github.com/dweomer/buildkit v0.6.2-0.20200111044149-7562b84375e4/go.mod h1:auJm/pdcHzciwG36is9O1A3kj+jJ3kc2wLdYIsBJj9g=
 github.com/dweomer/containerd v1.3.5-0.20200416225531-efdd59c500bf h1:2WbvYKDor5keKmBb3nOVr1YLIiufdPWyk3ul1N+y5iU=
 github.com/dweomer/containerd v1.3.5-0.20200416225531-efdd59c500bf/go.mod h1:2om0pJ92LKVun0Yn9IKZEGb/ebwvFSH5zKPt2YB7ILE=
+github.com/dweomer/containerd v1.3.5-0.20200508232507-1139e11acb7b h1:F91YE0cKw+AC/fA+6Z4gSwZzz0XNDFXTGkIyWvvObA0=
+github.com/dweomer/containerd v1.3.5-0.20200508232507-1139e11acb7b/go.mod h1:2om0pJ92LKVun0Yn9IKZEGb/ebwvFSH5zKPt2YB7ILE=
 github.com/dweomer/cri v1.11.1-0.20200508215717-5a3b30567ad1 h1:0xuYXC8rEnO56oOsriSomInG/FZ/tkV7lZnJQV1MTJo=
 github.com/dweomer/cri v1.11.1-0.20200508215717-5a3b30567ad1/go.mod h1:itvTywBS8wRcflCqlgX7shxq5Sp9H81Gk+nelbUmUB8=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=

--- a/vendor/github.com/containerd/containerd/services/opt/service.go
+++ b/vendor/github.com/containerd/containerd/services/opt/service.go
@@ -31,13 +31,15 @@ type Config struct {
 	Path string `toml:"path"`
 }
 
+var PluginConfig = Config{
+	Path: defaultPath,
+}
+
 func init() {
 	plugin.Register(&plugin.Registration{
 		Type: plugin.InternalPlugin,
 		ID:   "opt",
-		Config: &Config{
-			Path: defaultPath,
-		},
+		Config: &PluginConfig,
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			path := ic.Config.(*Config).Path
 			ic.Meta.Exports["path"] = path

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/containerd/aufs
 github.com/containerd/cgroups
 # github.com/containerd/console v1.0.0
 github.com/containerd/console
-# github.com/containerd/containerd v1.3.4 => github.com/dweomer/containerd v1.3.5-0.20200416225531-efdd59c500bf
+# github.com/containerd/containerd v1.3.4 => github.com/dweomer/containerd v1.3.5-0.20200508232507-1139e11acb7b
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/containers/v1


### PR DESCRIPTION
Properly sets ${opt.path} to be ${k3c.root} which helps to setup the
$PATH correctly. Additionally, append ${k3c.root}/bin/aux to the $PATH.

Also: properly set CLI option environment variables.