### PR TITLE
build: sync built images from k3c.io to k8s.io

### DIFF
--- a/cmd/daemon/daemon_linux.go
+++ b/cmd/daemon/daemon_linux.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/services/opt"
-
 	"github.com/containerd/containerd/cmd/containerd/command"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/services/opt"
 	"github.com/containerd/cri"
 	criconfig "github.com/containerd/cri/pkg/config"
 	"github.com/rancher/k3c/pkg/daemon"


### PR DESCRIPTION
After the refactor buildkit is configured to build images into the
k3c.io namespace because it's build-time containers will be
unceremoniously murdered by a kublet in the k8s.io namespace. This
change sets up an image event listener, post-bootstrap, that will copy
image content from the k3c.io namespace into the k8s.io namespace which
will allow k3c to build images and have them available to a co-located
k3s.