### PR TITLE
client: try $K3C_ADDRESS before default

### DIFF
--- a/pkg/cliclient/client.go
+++ b/pkg/cliclient/client.go
@@ -1,15 +1,17 @@
 package cliclient
 
 import (
+	"os"
+
 	"github.com/rancher/k3c/pkg/client"
 	"github.com/rancher/k3c/pkg/client/build"
 	"github.com/urfave/cli/v2"
 )
 
 func New(cli *cli.Context) (client.Client, error) {
-	return client.New(cli.Context, "")
+	return client.New(cli.Context, os.Getenv("K3C_ADDRESS"))
 }
 
 func NewBuilder(cli *cli.Context) (build.Client, error) {
-	return build.New(cli.Context, "")
+	return build.New(cli.Context, os.Getenv("K3C_ADDRESS"))
 }


### PR DESCRIPTION
If the value fot he `$K3C_ADDRESS` envrionment variable is not empty
then it will be used for establishing connections to the daemon. If it
is empty or does not exist the default will be used instead.