### PR TITLE
build: remove -fno-PIC from extldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)",)
 
-GO_EXTLDFLAGS ?= -fno-PIC -static
+GO_EXTLDFLAGS ?= -static
 GO_LDFLAGS ?= $(EXTRA_LDFLAGS)
 GO_LDFLAGS += -X ${PKG}/pkg/version.Version=$(VERSION)
 GO_LDFLAGS += -X ${PKG}/pkg/version.GitCommit=$(REVISION)


### PR DESCRIPTION
Trying to get the binary built for ARM to work for anybody.