### PR TITLE
support running as containerd

### DIFF
--- a/cmd/daemon/containerd.go
+++ b/cmd/daemon/containerd.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package daemon
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Containerd() {
+	logrus.Fatalf("%s only supported on Linux", os.Args[0])
+}

--- a/cmd/daemon/containerd_linux.go
+++ b/cmd/daemon/containerd_linux.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+	"k8s.io/klog"
+)
+
+func Containerd() {
+	app := newApp()
+	app.Name = "containerd"
+	app.HelpName = app.Name
+	app.Before = func(clx *cli.Context) error {
+		klog.InitFlags(nil)
+		return nil
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", app.Name, err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/containerd/containerd/pkg/seed"
+	"github.com/rancher/k3c/cmd/daemon"
 	"github.com/rancher/k3c/pkg/cli/app"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	seed.WithTimeAndRand()
-	app := app.New()
-	if err := app.Run(os.Args); err != nil {
-		logrus.Fatal(err)
+	self := filepath.Base(os.Args[0])
+	switch self {
+	case "containerd":
+		daemon.Containerd()
+	default:
+		app := app.New()
+		if err := app.Run(os.Args); err != nil {
+			logrus.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
When `k3c` is invoked as `containerd` (e.g. via symlink) it will act as
if `k3c daemon` was invoked allowing for drop-in replacement for
containerd.

Fixes #49 