### PR TITLE
cli: remove --force from pull

### DIFF
--- a/pkg/client/action/action-pull.go
+++ b/pkg/client/action/action-pull.go
@@ -15,7 +15,6 @@ import (
 )
 
 type PullImage struct {
-	Force    bool   `usage:""`
 	Platform string `usage:"Set platform if server is multi-platform capable"`
 }
 


### PR DESCRIPTION
It was a hold-over from the original k3c and is not used.
